### PR TITLE
Epanded Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,13 @@ yarn-error.log
 # Yarn Integrity file
 .yarn-integrity
 
+# Unused NPM Lockfile - NOTE: Use yarn instead.
+package-lock.json
+
+#IDE Stuff
 .idea
+.vscode
+
 *.7z
 
 

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -15,6 +15,7 @@
     "express-prettify": "^0.1.1",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^1.6.0",
+    "md5": "^2.3.0",
     "minimist": "^1.2.2",
     "otplib": "^12.0.1",
     "ws": "^7.2.5"

--- a/gateway/src/index.js
+++ b/gateway/src/index.js
@@ -5,6 +5,9 @@ const cors = require("cors");
 const axios = require("axios");
 const querystring = require("querystring");
 const otplib = require("otplib");
+const md5 = require("md5");
+
+const MAX_AUTH_ATTEMPTS = 5;
 
 const app = express();
 const { debugLog, listenPort } = require("./cliArgs");
@@ -101,47 +104,160 @@ app.all("/:gameId/*", async (request, response) => {
 	if (!gameApi) {
 		return response.status(404).json({ error: "GameIdNotFound" });
 	}
-	const query = request.query;
-	let totp;
-	if (gameApi.totpSecret) {
-		totp = otplib.totp.generate(gameApi.totpSecret);
-		if (request.method === "GET") {
-			query.totp = totp;
+	const headers = request.headers || {};
+	const queryParams = request.query || {};
+	const bodyParams = request.body || {};
+	let requestURL = `${gameApi.url}${endpoint}`;
+	const authScheme = gameApi.authScheme;
+	const authSecret = gameApi.authSecret;
+	if (authScheme) {
+		switch (authScheme)
+		{
+			case "totp":
+				if (authSecret) {
+					let totp = otplib.totp.generate(authSecret);
+					if (request.method === "GET") {
+						queryParams.totp = totp;
+						bodyParams.totp = totp;
+					}
+				}
+				break;
+			case "digest":
+				//Reference: https://en.wikipedia.org/wiki/Digest_access_authentication
+				if (authSecret) {
+					request.digestData = {
+						HA2: md5(`${request.method}:${requestURL}`),
+					}
+				}
+				break;
 		}
 	}
-	const queryString = Object.keys(query).length
-		? "?" + querystring.stringify(query)
-		: "";
-	try {
-		const { data } = await axios({
-			method: request.method,
-			url: `${gameApi.url}${endpoint}${queryString}`,
-			data: { ...request.body, totp },
-			timeout: 5000,
-		});
-		response.json(data);
-		gameApi.timeoutStartTime = 0;
-	} catch (err) {
-		if (err.code === "ECONNREFUSED") {
-			debugLog("Game API", gameApi.url, err.message);
-			response.status(504).json({ message: "Game API offline" });
-			if (!gameApi.timeoutStartTime) {
-				gameApi.timeoutStartTime = Date.now();
-			} else if (Date.now() - gameApi.timeoutStartTime > 1000 * 60) {
-				delete knownGameApis[gameId];
-			}
-		} else if (err.response && err.response.status) {
+	for (let i = 0; i <= MAX_AUTH_ATTEMPTS; i++)  {
+		if (i === MAX_AUTH_ATTEMPTS) {
 			debugLog(
 				"Game API",
+				gameApi.id,
+				request.method,
 				gameApi.url,
-				err.message,
-				`Status: ${err.response.status} ${err.response.statusText}`,
-				err.response.data
+				"Maximum authentication attempts reached."
 			);
-			response.status(err.response.status).json(err.response.data);
-		} else {
-			console.warn("Game API", err);
-			response.status(500).json({});
+			response.status(502).json({ message: "Failed to authenticate with game API." });
+			break;
+		}
+		try {
+			const queryParamString = Object.keys(queryParams).length
+				? "?" + querystring.stringify(queryParams)
+				: "";
+			const { data } = await axios({
+				method: request.method,
+				url: `${requestURL}${queryParamString}`,
+				data: bodyParams,
+				headers,
+				timeout: 5000,
+			});
+			response.json(data);
+			gameApi.timeoutStartTime = 0;
+			break;
+		} catch (err) {
+			let retryQuery = false;
+			if (err.code === "ECONNREFUSED") {
+				debugLog("Game API", gameApi.url, err.message);
+				response.status(504).json({ message: "Game API offline" });
+				if (!gameApi.timeoutStartTime) {
+					gameApi.timeoutStartTime = Date.now();
+				} else if (Date.now() - gameApi.timeoutStartTime > 1000 * 60) {
+					delete knownGameApis[gameId];
+				}
+			} else if (err.response && err.response.status) {
+				const { status, statusText } = err.response;
+				const responseHeaders = err.response.headers;
+				const responseData = err.response.data;
+				switch(status) {
+					case 401:
+						const authenticate = responseHeaders["WWW-Authenticate"];
+						debugLog(
+							"GameAPI",
+							gameApi.id,
+							request.method,
+							gameApi.url,
+							"Received unauthorized header:",
+							authenticate
+						);
+						const authenticateMap = {}
+						authenticate.split(", ").forEach((kvs) => {
+							let { key, value } = kvs.split("=");
+							if (key.left(7) === "Digest ") {
+								key = key.substring(7);
+							}
+							if (value[0] === '"' && value[value.length - 1] == '"') {
+								value = value.substring(1, value.length - 2);
+							}
+							authenticateMap[key] = value;
+						});
+						switch(authScheme) {
+							case "digest":
+								const { qop, realm, nonce } = authenticateMap;
+								if (qop === "auth" && nonce) {
+									const HA1 = md5(`gmanman:${realm}:${authSecret}`);
+									const { HA2 } = request.digestData;
+									authenticateMap.response = md5(`${HA1}:${nonce}:${HA2}`);
+									headers["Authorization"] = `Digest ${authenticateMap.keys().map((key) => `${key}=${authenticateMap[key]}`).join(", ")}`
+									debugLog(
+										"GameAPI",
+										gameApi.id,
+										request.method,
+										gameApi.url,
+										`HA1: gmanman:${realm}:${authSecret} => ${HA1}`,
+										`nonce: ${nonce}`
+										`HA2: ${request.method}:${requestURL} => ${HA2}`,
+										headers["Authorization"]
+									);
+									retryQuery = true;
+								}
+								else {
+									debugLog(
+										"Game API",
+										gameApi.id,
+										request.method,
+										gameApi.url,
+										"API registered with digest authentication, but server did not return correct authenticate header.",
+										`Status: ${status} ${statusText}`,
+										responseHeaders
+									);
+									response.status(502).json({ message: "Game API had invalid authenticate header.", responseHeaders })
+								}
+								break;
+							default:
+								debugLog(
+									"Game API",
+									gameApi.id,
+									request.method,
+									gameApi.url,
+									"API returned unauthorized status, but no authentication scheme that supports re-transmission was registered.",
+									`Scheme: ${authScheme}`
+								);
+								response.status(502).json({ message: "Game API misconfigured authentication scheme.", scheme: authScheme });
+								break;
+						}
+						break;
+					default:
+						debugLog(
+							"Game API",
+							gameApi.url,
+							err.message,
+							`Status: ${status} ${statusText}`,
+							responseData
+						);
+						response.status(status).json(responseData);
+				}
+			} else {
+				console.warn("Game API", err);
+				response.status(500).json({});
+			}
+			if (retryQuery) {
+				continue;
+			}
+			break;
 		}
 	}
 });


### PR DESCRIPTION
Generalized authentication concepts: While registering, APIs now optionally provide `authScheme` and `authSecret`.
If `authScheme` is `digest`, the gateway will retransmit a digest response if it receives a 401 status with appropriate digest information, using `"gmanman"` as the login, and `authSecret` as the password.
If `authScheme` is `totp`, the gateway will use the totp library to encode the `authSecret` value, and provide the result in both the query parameters and body. (In theory, this logic was not changed, only the registration variables driving it.)

Retransmission is accomplished by putting the primary request logic in a for loop that repeats the query a maximum number of times, with authentication handlers modifying the request in order to facilitate the handshake.

Also includes a couple minor changes, such as moving initializations around since some authentication logic required those variables earlier than previously. Also checks in package-lock.json, as that file is intended for source control: https://docs.npmjs.com/configuring-npm/package-lock-json.html